### PR TITLE
Brandon/kawasaki

### DIFF
--- a/client/src/components/modules/CPCanvas.tsx
+++ b/client/src/components/modules/CPCanvas.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useMemo, useRef, useState } from "react";
+import React, { useLayoutEffect, useRef, useState } from "react";
 
 import {
   CIRCLE_RADIUS,
@@ -15,10 +15,8 @@ import {
   Mode,
   MvMode,
   ViewBox,
-  defaultGridSettings,
 } from "../../types/ui";
 import { getSnapPoints } from "../../utils/cpEdit";
-import { checkVertexFoldable } from "../../utils/kawasaki";
 import { pointsEqual } from "../../utils/cp";
 import { useChangeMvMode } from "../hooks/changeMvMode";
 import { useDeleteMode } from "../hooks/deleteMode";
@@ -99,9 +97,12 @@ const renderCP = (
 export interface CPCanvasProps {
   cp: CP | null;
   setCP: (cp: CP) => void;
+  gridSettings: GridSettings;
+  setGridSettings: React.Dispatch<React.SetStateAction<GridSettings>>;
+  invalidVertices: Point[];
 }
 
-const CPCanvas: React.FC<CPCanvasProps> = ({ cp, setCP }) => {
+const CPCanvas: React.FC<CPCanvasProps> = ({ cp, setCP, gridSettings, setGridSettings, invalidVertices }) => {
   const editorRef = useRef<HTMLDivElement | null>(null);
 
   const [width, setWidth] = useState<number>(0);
@@ -128,13 +129,6 @@ const CPCanvas: React.FC<CPCanvasProps> = ({ cp, setCP }) => {
     setSelection,
     edgeOnClick: selectEdgeOnClick,
   } = useSelectMode(mode);
-  const [gridSettings, setGridSettings] =
-    useState<GridSettings>(defaultGridSettings);
-
-  const invalidVertices = useMemo(() => {
-    if (!cp || !gridSettings.checkFoldability) return [];
-    return cp.vertices.filter(v => !checkVertexFoldable(v, cp));
-  }, [cp, gridSettings.checkFoldability]);
 
   const {
     ui: drawUi,

--- a/client/src/components/modules/CPCanvas.tsx
+++ b/client/src/components/modules/CPCanvas.tsx
@@ -1,8 +1,8 @@
 import React, { useLayoutEffect, useRef, useState } from "react";
 
 import {
-  CIRCLE_RADIUS,
   CIRCLE_OPACITY,
+  CIRCLE_RADIUS,
   modeIcons,
   modeKeys,
   modeMap,
@@ -10,14 +10,9 @@ import {
   mvMap,
 } from "../../constants/editor";
 import { CP, Edge, Point } from "../../types/cp";
-import {
-  GridSettings,
-  Mode,
-  MvMode,
-  ViewBox,
-} from "../../types/ui";
-import { getSnapPoints } from "../../utils/cpEdit";
+import { GridSettings, Mode, MvMode, ViewBox } from "../../types/ui";
 import { pointsEqual } from "../../utils/cp";
+import { getSnapPoints } from "../../utils/cpEdit";
 import { useChangeMvMode } from "../hooks/changeMvMode";
 import { useDeleteMode } from "../hooks/deleteMode";
 import { useDrawMode } from "../hooks/drawMode";
@@ -45,17 +40,17 @@ const renderCP = (
       ? getSnapPoints(cp, gridSettings, viewBox)
       : cp.vertices;
   const verticesComponents = vertices.map((v: Point, idx: number) => {
-    const isInvalid = invalidVertices.some(iv => pointsEqual(iv, v));
+    const isInvalid = invalidVertices.some((iv) => pointsEqual(iv, v));
     return (
       <g key={`vertex-${idx}`}>
         {isInvalid && (
-           <circle
-             cx={v.x}
-             cy={v.y}
-             r={CIRCLE_RADIUS / viewBox.zoom}
-             fill="red"
-             opacity={CIRCLE_OPACITY}
-           />
+          <circle
+            cx={v.x}
+            cy={v.y}
+            r={CIRCLE_RADIUS / viewBox.zoom}
+            fill="red"
+            opacity={CIRCLE_OPACITY}
+          />
         )}
         <circle
           cx={v.x}
@@ -102,7 +97,13 @@ export interface CPCanvasProps {
   invalidVertices: Point[];
 }
 
-const CPCanvas: React.FC<CPCanvasProps> = ({ cp, setCP, gridSettings, setGridSettings, invalidVertices }) => {
+const CPCanvas: React.FC<CPCanvasProps> = ({
+  cp,
+  setCP,
+  gridSettings,
+  setGridSettings,
+  invalidVertices,
+}) => {
   const editorRef = useRef<HTMLDivElement | null>(null);
 
   const [width, setWidth] = useState<number>(0);

--- a/client/src/components/modules/CPCanvas.tsx
+++ b/client/src/components/modules/CPCanvas.tsx
@@ -1,7 +1,8 @@
-import React, { useLayoutEffect, useRef, useState } from "react";
+import React, { useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import {
   CIRCLE_RADIUS,
+  CIRCLE_OPACITY,
   modeIcons,
   modeKeys,
   modeMap,
@@ -17,6 +18,8 @@ import {
   defaultGridSettings,
 } from "../../types/ui";
 import { getSnapPoints } from "../../utils/cpEdit";
+import { checkVertexFoldable } from "../../utils/kawasaki";
+import { pointsEqual } from "../../utils/cp";
 import { useChangeMvMode } from "../hooks/changeMvMode";
 import { useDeleteMode } from "../hooks/deleteMode";
 import { useDrawMode } from "../hooks/drawMode";
@@ -37,20 +40,32 @@ const renderCP = (
   ) => (event: React.PointerEvent<SVGPathElement>) => void,
   mode: Mode,
   gridSettings: GridSettings,
+  invalidVertices: Point[],
 ) => {
   const vertices =
     mode === Mode.Drawing
       ? getSnapPoints(cp, gridSettings, viewBox)
       : cp.vertices;
   const verticesComponents = vertices.map((v: Point, idx: number) => {
+    const isInvalid = invalidVertices.some(iv => pointsEqual(iv, v));
     return (
-      <circle
-        cx={v.x}
-        cy={v.y}
-        r={Math.min(CIRCLE_RADIUS / viewBox.zoom, CIRCLE_RADIUS / 1.5)}
-        className="CP-vertex"
-        key={`vertex-${idx}`}
-      />
+      <g key={`vertex-${idx}`}>
+        {isInvalid && (
+           <circle
+             cx={v.x}
+             cy={v.y}
+             r={CIRCLE_RADIUS / viewBox.zoom}
+             fill="red"
+             opacity={CIRCLE_OPACITY}
+           />
+        )}
+        <circle
+          cx={v.x}
+          cy={v.y}
+          r={Math.min(CIRCLE_RADIUS / viewBox.zoom, CIRCLE_RADIUS / 1.5)}
+          className="CP-vertex"
+        />
+      </g>
     );
   });
 
@@ -115,6 +130,11 @@ const CPCanvas: React.FC<CPCanvasProps> = ({ cp, setCP }) => {
   } = useSelectMode(mode);
   const [gridSettings, setGridSettings] =
     useState<GridSettings>(defaultGridSettings);
+
+  const invalidVertices = useMemo(() => {
+    if (!cp || !gridSettings.checkFoldability) return [];
+    return cp.vertices.filter(v => !checkVertexFoldable(v, cp));
+  }, [cp, gridSettings.checkFoldability]);
 
   const {
     ui: drawUi,
@@ -281,6 +301,7 @@ const CPCanvas: React.FC<CPCanvasProps> = ({ cp, setCP }) => {
                   edgeOnClick,
                   mode,
                   gridSettings,
+                  invalidVertices,
                 )}
             </g>
             {drawUi}

--- a/client/src/components/modules/GridMenu.tsx
+++ b/client/src/components/modules/GridMenu.tsx
@@ -76,6 +76,18 @@ const GridMenu: React.FC<GridSettingsProps> = ({
           />
           Extend grid
         </label>
+        <label className="Grid-settings-form-label">
+          <input
+            type="checkbox"
+            checked={gridSettings.checkFoldability}
+            onChange={(e) =>
+              setGridSettings((prev: GridSettings) => {
+                return { ...prev, checkFoldability: e.target.checked };
+              })
+            }
+          />
+          Check foldability
+        </label>
         <label className="Grid-settings-form-label" htmlFor="gridSize"></label>
         <input
           className="Grid-settings-form-text"

--- a/client/src/components/modules/Viewer3D.css
+++ b/client/src/components/modules/Viewer3D.css
@@ -1,3 +1,48 @@
 .Viewer {
   width: 40vw;
+  position: relative;
+  height: 100%;
+}
+
+.Viewer-controls {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background-color: rgba(255, 255, 255, 0.85);
+  padding: 12px;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  pointer-events: auto;
+}
+
+.Viewer-controls label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  font-family: inherit;
+  font-size: 14px;
+}
+
+.Viewer-controls input[type="range"] {
+  width: 100px;
+}
+
+.Viewer-reset {
+  margin-top: 4px;
+  padding: 4px 8px;
+  background-color: #f0f0f0;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  transition: background-color 0.2s;
+}
+
+.Viewer-reset:hover {
+  background-color: #e0e0e0;
 }

--- a/client/src/components/modules/Viewer3D.css
+++ b/client/src/components/modules/Viewer3D.css
@@ -12,7 +12,8 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  background-color: rgba(255, 255, 255, 0.85);
+  background-color: var(--foreground);
+  color: var(--text-color);
   padding: 12px;
   border-radius: 8px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
@@ -33,9 +34,10 @@
 }
 
 .Viewer-reset {
+  color: var(--text-color-dark);
   margin-top: 4px;
   padding: 4px 8px;
-  background-color: #f0f0f0;
+  background-color: var(--foreground-secondary);
   border: 1px solid #ccc;
   border-radius: 4px;
   cursor: pointer;
@@ -44,5 +46,6 @@
 }
 
 .Viewer-reset:hover {
-  background-color: #e0e0e0;
+  color: var(--text-color);
+  background-color: var(--highlight);
 }

--- a/client/src/components/modules/Viewer3D.tsx
+++ b/client/src/components/modules/Viewer3D.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 
 import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
@@ -14,6 +14,9 @@ export interface Viewer3DProps {
 }
 
 export const Viewer3D: React.FC<Viewer3DProps> = ({ cp }) => {
+  const [pitch, setPitch] = useState<number>(0);
+  const [roll, setRoll] = useState<number>(0);
+
   const foldedFaces = useMemo(() => {
     if (cp === null) return [];
     return foldFaces(findFaces(cp), cp);
@@ -21,10 +24,35 @@ export const Viewer3D: React.FC<Viewer3DProps> = ({ cp }) => {
 
   return (
     <div className="Viewer">
+      <div className="Viewer-controls">
+        <label>
+          Pitch
+          <input
+            type="range"
+            min="-180"
+            max="180"
+            value={pitch}
+            onChange={(e) => setPitch(Number(e.target.value))}
+          />
+        </label>
+        <label>
+          Roll
+          <input
+            type="range"
+            min="-180"
+            max="180"
+            value={roll}
+            onChange={(e) => setRoll(Number(e.target.value))}
+          />
+        </label>
+        <button className="Viewer-reset" onClick={() => { setPitch(0); setRoll(0); }}>Reset</button>
+      </div>
       <Canvas>
-        {foldedFaces.map((f: FoldedFace) => (
-          <Polygon3D key={`Face-${f.id}`} vertices={f.border} />
-        ))}
+        <group rotation={[(pitch * Math.PI) / 180, 0, (roll * Math.PI) / 180]}>
+          {foldedFaces.map((f: FoldedFace) => (
+            <Polygon3D key={`Face-${f.id}`} vertices={f.border} />
+          ))}
+        </group>
         <OrbitControls />
       </Canvas>
     </div>

--- a/client/src/components/modules/Viewer3D.tsx
+++ b/client/src/components/modules/Viewer3D.tsx
@@ -2,8 +2,9 @@ import React, { useMemo, useState } from "react";
 
 import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
-
-import { CP } from "../../types/cp";
+import { CIRCLE_RADIUS,CIRCLE_OPACITY} from "../../constants/editor";
+import { CP, Point } from "../../types/cp";
+import { pointsEqual } from "../../utils/cp";
 import { FoldedFace } from "../../types/xray";
 import { findFaces, foldFaces } from "../../utils/xray";
 import Polygon3D from "./Polygon";
@@ -11,16 +12,45 @@ import "./Viewer3D.css";
 
 export interface Viewer3DProps {
   cp: CP | null;
+  invalidVertices?: Point[];
+  checkFoldability?: boolean;
 }
 
-export const Viewer3D: React.FC<Viewer3DProps> = ({ cp }) => {
+export const Viewer3D: React.FC<Viewer3DProps> = ({ 
+  cp, 
+  invalidVertices = [], 
+  checkFoldability = false 
+}) => {
   const [pitch, setPitch] = useState<number>(0);
   const [roll, setRoll] = useState<number>(0);
 
-  const foldedFaces = useMemo(() => {
-    if (cp === null) return [];
-    return foldFaces(findFaces(cp), cp);
+  const { foldedFaces, faces2D } = useMemo(() => {
+    if (cp === null) return { foldedFaces: [], faces2D: [] };
+    const f2d = findFaces(cp);
+    return {
+      foldedFaces: foldFaces(f2d, cp),
+      faces2D: f2d
+    };
   }, [cp]);
+
+  const invalid3DVertices = useMemo(() => {
+    if (!checkFoldability || invalidVertices.length === 0) return [];
+    
+    const mappedVertices: [number, number, number][] = [];
+    
+    invalidVertices.forEach(iv => {
+      // Find this point in 2D faces to get its 3D counterpart
+      for (let i = 0; i < faces2D.length; i++) {
+        const pointIndex = faces2D[i].border.findIndex(p => pointsEqual(p, iv));
+        if (pointIndex !== -1) {
+          mappedVertices.push(foldedFaces[i].border[pointIndex]);
+          break; // Found it, move to next invalid vertex
+        }
+      }
+    });
+
+    return mappedVertices;
+  }, [checkFoldability, invalidVertices, faces2D, foldedFaces]);
 
   return (
     <div className="Viewer">
@@ -51,6 +81,12 @@ export const Viewer3D: React.FC<Viewer3DProps> = ({ cp }) => {
         <group rotation={[(pitch * Math.PI) / 180, 0, (roll * Math.PI) / 180]}>
           {foldedFaces.map((f: FoldedFace) => (
             <Polygon3D key={`Face-${f.id}`} vertices={f.border} />
+          ))}
+          {invalid3DVertices.map((v, i) => (
+            <mesh key={`invalid-v-${i}`} position={v}>
+              <sphereGeometry args={[CIRCLE_RADIUS,16,16]} />
+              <meshBasicMaterial color="red" transparent opacity={CIRCLE_OPACITY} />
+            </mesh>
           ))}
         </group>
         <OrbitControls />

--- a/client/src/components/modules/Viewer3D.tsx
+++ b/client/src/components/modules/Viewer3D.tsx
@@ -1,11 +1,13 @@
+/* eslint-disable react/no-unknown-property */
 import React, { useMemo, useState } from "react";
 
 import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
-import { CIRCLE_RADIUS,CIRCLE_OPACITY} from "../../constants/editor";
+
+import { CIRCLE_OPACITY, CIRCLE_RADIUS } from "../../constants/editor";
 import { CP, Point } from "../../types/cp";
-import { pointsEqual } from "../../utils/cp";
 import { FoldedFace } from "../../types/xray";
+import { pointsEqual } from "../../utils/cp";
 import { findFaces, foldFaces } from "../../utils/xray";
 import Polygon3D from "./Polygon";
 import "./Viewer3D.css";
@@ -16,10 +18,10 @@ export interface Viewer3DProps {
   checkFoldability?: boolean;
 }
 
-export const Viewer3D: React.FC<Viewer3DProps> = ({ 
-  cp, 
-  invalidVertices = [], 
-  checkFoldability = false 
+export const Viewer3D: React.FC<Viewer3DProps> = ({
+  cp,
+  invalidVertices = [],
+  checkFoldability = false,
 }) => {
   const [pitch, setPitch] = useState<number>(0);
   const [roll, setRoll] = useState<number>(0);
@@ -29,19 +31,21 @@ export const Viewer3D: React.FC<Viewer3DProps> = ({
     const f2d = findFaces(cp);
     return {
       foldedFaces: foldFaces(f2d, cp),
-      faces2D: f2d
+      faces2D: f2d,
     };
   }, [cp]);
 
   const invalid3DVertices = useMemo(() => {
     if (!checkFoldability || invalidVertices.length === 0) return [];
-    
+
     const mappedVertices: [number, number, number][] = [];
-    
-    invalidVertices.forEach(iv => {
+
+    invalidVertices.forEach((iv) => {
       // Find this point in 2D faces to get its 3D counterpart
       for (let i = 0; i < faces2D.length; i++) {
-        const pointIndex = faces2D[i].border.findIndex(p => pointsEqual(p, iv));
+        const pointIndex = faces2D[i].border.findIndex((p) =>
+          pointsEqual(p, iv),
+        );
         if (pointIndex !== -1) {
           mappedVertices.push(foldedFaces[i].border[pointIndex]);
           break; // Found it, move to next invalid vertex
@@ -75,7 +79,15 @@ export const Viewer3D: React.FC<Viewer3DProps> = ({
             onChange={(e) => setRoll(Number(e.target.value))}
           />
         </label>
-        <button className="Viewer-reset" onClick={() => { setPitch(0); setRoll(0); }}>Reset</button>
+        <button
+          className="Viewer-reset"
+          onClick={() => {
+            setPitch(0);
+            setRoll(0);
+          }}
+        >
+          Reset
+        </button>
       </div>
       <Canvas>
         <group rotation={[(pitch * Math.PI) / 180, 0, (roll * Math.PI) / 180]}>
@@ -84,8 +96,12 @@ export const Viewer3D: React.FC<Viewer3DProps> = ({
           ))}
           {invalid3DVertices.map((v, i) => (
             <mesh key={`invalid-v-${i}`} position={v}>
-              <sphereGeometry args={[CIRCLE_RADIUS,16,16]} />
-              <meshBasicMaterial color="red" transparent opacity={CIRCLE_OPACITY} />
+              <sphereGeometry args={[CIRCLE_RADIUS, 16, 16]} />
+              <meshBasicMaterial
+                color="red"
+                transparent
+                opacity={CIRCLE_OPACITY}
+              />
             </mesh>
           ))}
         </group>

--- a/client/src/components/pages/Editor.tsx
+++ b/client/src/components/pages/Editor.tsx
@@ -24,11 +24,12 @@ const Editor: React.FC = () => {
 
   const [cp, setCP] = useState<CP | null>(null);
 
-  const [gridSettings, setGridSettings] = useState<GridSettings>(defaultGridSettings);
+  const [gridSettings, setGridSettings] =
+    useState<GridSettings>(defaultGridSettings);
 
   const invalidVertices = React.useMemo(() => {
     if (!cp || !gridSettings.checkFoldability) return [];
-    return cp.vertices.filter(v => !checkVertexFoldable(v, cp));
+    return cp.vertices.filter((v) => !checkVertexFoldable(v, cp));
   }, [cp, gridSettings.checkFoldability]);
 
   if (!context) {
@@ -90,16 +91,20 @@ const Editor: React.FC = () => {
     <>
       <Navbar />
       <div className="Editor">
-        <CPCanvas 
-          cp={cp} 
-          setCP={setCP} 
-          gridSettings={gridSettings} 
-          setGridSettings={setGridSettings} 
-          invalidVertices={invalidVertices} 
+        <CPCanvas
+          cp={cp}
+          setCP={setCP}
+          gridSettings={gridSettings}
+          setGridSettings={setGridSettings}
+          invalidVertices={invalidVertices}
         />
         <div className="Editor-sidebar">
           <div className="Viewer-container">
-            <Viewer3D cp={cp} invalidVertices={invalidVertices} checkFoldability={gridSettings.checkFoldability} />
+            <Viewer3D
+              cp={cp}
+              invalidVertices={invalidVertices}
+              checkFoldability={gridSettings.checkFoldability}
+            />
           </div>
           {/* <div className="viewer-buttons">
             <button>Hi</button>

--- a/client/src/components/pages/Editor.tsx
+++ b/client/src/components/pages/Editor.tsx
@@ -5,7 +5,9 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import { ServerCPDto } from "../../../../dto/dto";
 import { CP } from "../../types/cp";
+import { GridSettings, defaultGridSettings } from "../../types/ui";
 import { convertServerCPDto, convertToClientCPDto } from "../../utils/cp";
+import { checkVertexFoldable } from "../../utils/kawasaki";
 import { get, post } from "../../utils/requests";
 import { UserContext } from "../App";
 import CPCanvas from "../modules/CPCanvas";
@@ -21,6 +23,13 @@ const Editor: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
 
   const [cp, setCP] = useState<CP | null>(null);
+
+  const [gridSettings, setGridSettings] = useState<GridSettings>(defaultGridSettings);
+
+  const invalidVertices = React.useMemo(() => {
+    if (!cp || !gridSettings.checkFoldability) return [];
+    return cp.vertices.filter(v => !checkVertexFoldable(v, cp));
+  }, [cp, gridSettings.checkFoldability]);
 
   if (!context) {
     return <Error />;
@@ -81,10 +90,16 @@ const Editor: React.FC = () => {
     <>
       <Navbar />
       <div className="Editor">
-        <CPCanvas cp={cp} setCP={setCP} />
+        <CPCanvas 
+          cp={cp} 
+          setCP={setCP} 
+          gridSettings={gridSettings} 
+          setGridSettings={setGridSettings} 
+          invalidVertices={invalidVertices} 
+        />
         <div className="Editor-sidebar">
           <div className="Viewer-container">
-            <Viewer3D cp={cp} />
+            <Viewer3D cp={cp} invalidVertices={invalidVertices} checkFoldability={gridSettings.checkFoldability} />
           </div>
           {/* <div className="viewer-buttons">
             <button>Hi</button>

--- a/client/src/constants/editor.ts
+++ b/client/src/constants/editor.ts
@@ -4,7 +4,8 @@ import selectIcon from "../assets/icons/protractor.svg";
 import changeMvIcon from "../assets/icons/switch_mv.svg";
 import { Mode, MvMode } from "../types/ui";
 
-export const CIRCLE_RADIUS = 0.015;
+export const CIRCLE_RADIUS = 0.02;
+export const CIRCLE_OPACITY = 0.3;
 
 export const DRAW_SNAP_TOLERANCE_PX = 20;
 export const DRAW_PREVIEW_DOT_RADIUS_PX = 4;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -9,6 +9,7 @@
   --background-dark: #061156;
   --background-light: #3344b2;
   --foreground: #374b9e;
+  --highlight: #076fbf;
   --foreground-secondary: #cccccc;
   --text-color: #ffffff;
   --text-color-secondary: #dddddd;
@@ -32,6 +33,7 @@
   --background-dark: #aaaaaa;
   --background-light: #ffffff;
   --foreground: #dddddd;
+  --highlight: #c0c0c0;
   --foreground-secondary: #cccccc;
   --text-color: #000000;
   --text-color-secondary: #333333;

--- a/client/src/types/ui.ts
+++ b/client/src/types/ui.ts
@@ -22,10 +22,12 @@ export interface GridSettings {
   showGrid: boolean;
   gridSize: number;
   extendGrid: boolean;
+  checkFoldability: boolean;
 }
 
 export const defaultGridSettings = {
   showGrid: false,
   gridSize: 8,
   extendGrid: false,
+  checkFoldability: false,
 };

--- a/client/src/utils/kawasaki.ts
+++ b/client/src/utils/kawasaki.ts
@@ -1,175 +1,62 @@
-// /*
-// Kawasaki's theorem related utility functions
-//
-//  - check if a particular vertex is foldable according to Kawasaki's theorem
-//  - check all vertices and find ones that are not foldable by Kawasaki
-//  - Find candidate creases for making a vertex foldable
-// */
-// import { Fold } from "../types/fold";
-// import * as float from "./float";
-// import * as matrices from "./matrices";
-//
-// function getRotationMatrices(
-//   fold: Fold,
-//   vertexIndex: number,
-// ): null | { theta: number; rho: number; matrix: number[][] }[] {
-//   /*
-//     Get the rotation matrices for a particular vertex, sorted by theta. If the vertex is on the edge, return null
-//     Outputs a zip of thetas, foldAngles, and matrices
-//     */
-//   const vertex = fold.vertices_coords[vertexIndex];
-//   const connectedVertices = fold.vertices_vertices[vertexIndex]; //indices of connected vertices
-//   const connectedEdges = fold.vertices_edges[vertexIndex];
-//   const edge_assignments = connectedEdges.map(
-//     (edgeIndex) => fold.edges_assignment[edgeIndex],
-//   );
-//   const edge_foldAngles = connectedEdges.map(
-//     (edgeIndex) => fold.edges_foldAngle[edgeIndex],
-//   ); //assume radians
-//
-//   //If the vertex is on the edge, kawasaki's theorem doesn't apply. "B" is border, "C" is cut (not commonly used)
-//   if (edge_assignments.includes("B") || edge_assignments.includes("C")) {
-//     return null;
-//   }
-//
-//   //Convert connected vertices into thetas
-//   const thetas = connectedVertices.map((connectedVertexIndex) => {
-//     const connectedVertex = fold.vertices_coords[connectedVertexIndex];
-//     const x = connectedVertex[0] - vertex[0];
-//     const y = connectedVertex[1] - vertex[1];
-//     return Math.atan2(y, x);
-//   });
-//
-//   // Sort thetas in ascending order and zip with edge_foldAngles
-//   const zipped = thetas
-//     .map((theta, index) => ({ theta, foldAngle: edge_foldAngles[index] }))
-//     .sort((a, b) => b.theta - a.theta);
-//
-//   return zipped.map(({ theta, foldAngle }) => ({
-//     theta: theta,
-//     rho: foldAngle,
-//     matrix: matrices.rotationMatrix(theta, foldAngle),
-//   }));
-// }
-//
-// //=========================================================
-// // 3D functions
-//
-// export function checkKawasakiVertex(fold: Fold, vertexIndex: number): boolean {
-//   /*
-//     Check if a particular vertex is foldable by Kawasaki's theorem. This is a necessary condition, not sufficient. Returns true if foldable and false if not
-//     Should run in O(n) time where n is the number of connected vertices. In practice, n rarely exceeds 8 or so
-//     */
-//
-//   if (!fold.vertices_coords || !fold.vertices_coords[vertexIndex]) {
-//     console.warn(`Vertex ${vertexIndex} is undefined or invalid`);
-//     return false;
-//   }
-//   const rotationMatrices = getRotationMatrices(fold, vertexIndex);
-//   if (rotationMatrices === null) {
-//     return true; //vertex IS foldable
-//   }
-//
-//   //Multiply the rotation matrices
-//   const finalMatrix = matrices.multiplyMatricesList(
-//     rotationMatrices.map(({ matrix }) => matrix),
-//   );
-//
-//   // Check if the final matrix is an identity matrix. Equivalent to checking if rotation vector is 0
-//   return matrices.isIdentity(finalMatrix);
-// }
-//
-// export function makeKawasakiFoldable(
-//   fold: Fold,
-//   vertexIndex: number,
-// ): Array<{ theta: number; rho: number }> | null {
-//   /*
-//     Check if a vertex can be made foldable by Kawasaki's theorem. If it can, return a list of candidate creases in the form of (theta, rho) that can be added to make it foldable. If not, or if it is already foldable, return null.
-//     */
-//   if (checkKawasakiVertex(fold, vertexIndex)) {
-//     return null; //vertex is already foldable
-//   }
-//   const rotationMatrices = getRotationMatrices(fold, vertexIndex);
-//   if (rotationMatrices === null) {
-//     return null; //vertex is on the edge, does not need to be made foldable
-//   }
-//   // console.log("Rotation matrices: ", rotationMatrices);
-//   //rotationMatrices is a circular list. Make n copies so that each copy starts with a different rotation matrix
-//   console.log("Rotation matrices: ", rotationMatrices);
-//   const n = rotationMatrices.length;
-//   const rotationMatricesCopies = Array.from({ length: n }, (_, index) => {
-//     return rotationMatrices
-//       .slice(index)
-//       .concat(rotationMatrices.slice(0, index));
-//   });
-//   //for each copy, multiply the matrices to get a net rotation
-//   const netMatrices = rotationMatricesCopies.map((rotationMatrices) =>
-//     matrices.multiplyMatricesList(
-//       rotationMatrices.map(({ theta, rho, matrix }) => matrix),
-//     ),
-//   );
-//
-//   console.log("Net matrices: ", netMatrices);
-//   const candidateCreases: Array<{
-//     theta: number;
-//     rho: number;
-//     matrix: number[][];
-//   }> = [];
-//   //For each matrix in netMatrices, check if matrix[1][0] == matrix[0][1]. This means the rotation matrix has no z component, and can be expressed as a single crease
-//   // console.log("Net matrices: ", netMatrices);
-//   for (const matrix of netMatrices) {
-//     if (float.eq(matrix[1][0], matrix[0][1])) {
-//       //Find the theta and rho values of this single creases
-//       const theta = Math.atan2(matrix[2][1], matrix[0][2]); //really is the theta of the transpose, which is also the inverse
-//       const rho = Math.atan2(matrix[2][1] / Math.cos(theta), matrix[2][2]); //this is also the rho of the transpose
-//       candidateCreases.push({ theta: theta, rho: rho, matrix: matrix });
-//       candidateCreases.push({
-//         theta: theta >= 0 ? theta - Math.PI : theta + Math.PI,
-//         rho: -rho,
-//         matrix: matrix,
-//       }); //add the opposite solution
-//     }
-//   }
-//   console.log("Candidate creases: ", candidateCreases);
-//   //For each candidate crease, check if it actually makes the vertex foldable.
-//   let verifiedCreases: Array<{ theta: number; rho: number }> = [];
-//
-//   for (const candidate of candidateCreases) {
-//     //insert the candidate
-//     const newRotationMatrices = rotationMatrices.concat(candidate);
-//     //sort by theta
-//     newRotationMatrices.sort((a, b) => a.theta - b.theta);
-//     // console.log(newRotationMatrices);
-//     //multiply matrices
-//     const finalMatrix = matrices.multiplyMatricesList(
-//       newRotationMatrices.map(({ matrix }) => matrix),
-//     );
-//     //check if the vertex with this candidate would be foldable
-//     // const rotationVector = matrices.rotationMatrixToVector(finalMatrix);
-//     // console.log(rotationVector);
-//     // console.log("======")
-//     // console.log(finalMatrix);
-//     if (matrices.isIdentity(finalMatrix)) {
-//       verifiedCreases.push({ theta: candidate.theta, rho: candidate.rho });
-//     }
-//   }
-//   // console.log("Verified creases: ", verifiedCreases);
-//   //Eliminate duplicate solutions
-//   //NOTE: might end up with both pi and -pi because maekawa/local self intersection is not implemented
-//   verifiedCreases = verifiedCreases.filter(
-//     (crease, index, self) =>
-//       index ===
-//       self.findIndex(
-//         (t) => float.eq(t.theta, crease.theta) && float.eq(t.rho, crease.rho),
-//       ),
-//   );
-//   return verifiedCreases;
-// }
-//
-// export function angleDifference(a: number, b: number): number {
-//   /*
-//     Get the difference between two angles in radians. Returns a value between -pi and pi
-//     */
-//   const diff = a - b;
-//   return Math.atan2(Math.sin(diff), Math.cos(diff));
-// }
+import { CP, EdgeAssignment, Point } from "../types/cp";
+import { pointsEqual } from "./cp";
+import { Quaternion, isUnitQuaternion, multiplyQuaternions } from "./quaternions";
+
+export const checkVertexFoldable = (vertex: Point, cp: CP): boolean => {
+  // Find all edges connected to this vertex
+  const connectedEdges = cp.edges.filter(
+    (e) => pointsEqual(e.vertex1, vertex) || pointsEqual(e.vertex2, vertex)
+  );
+
+  // If there are any border or cut edges connected, it's foldable (not constrained)
+  if (
+    connectedEdges.some(
+      (e) => e.assignment === EdgeAssignment.Border || e.assignment === EdgeAssignment.Cut
+    )
+  ) {
+    return true;
+  }
+
+  // Filter for structural fold lines (Mountain and Valley, possibly Flat)
+  // Ignoring Aux
+  const foldEdges = connectedEdges.filter(
+    (e) =>
+      e.assignment === EdgeAssignment.Mountain ||
+      e.assignment === EdgeAssignment.Valley ||
+      e.assignment === EdgeAssignment.Flat
+  );
+
+  if (foldEdges.length === 0) return true;
+
+  // Gather theta and rho
+  const edgeData = foldEdges.map((e) => {
+    // Determine the vector pointing AWAY from the vertex
+    const otherPoint = pointsEqual(e.vertex1, vertex) ? e.vertex2 : e.vertex1;
+    const dx = otherPoint.x - vertex.x;
+    const dy = otherPoint.y - vertex.y;
+    const theta = Math.atan2(dy, dx);
+    const rho = e.foldAngle || 0; // foldAngle in radians
+    return { theta, rho };
+  });
+
+  // Sort by theta
+  edgeData.sort((a, b) => a.theta - b.theta);
+
+  // Map to quaternions
+  const quaternions: Quaternion[] = edgeData.map(({ theta, rho }) => {
+    return [
+      Math.cos(rho / 2),
+      Math.sin(rho / 2) * Math.cos(theta),
+      Math.sin(rho / 2) * Math.sin(theta),
+      0,
+    ];
+  });
+
+  // Multiply all quaternions in order
+  let result = quaternions[0];
+  for (let i = 1; i < quaternions.length; i++) {
+    result = multiplyQuaternions(result, quaternions[i]);
+  }
+
+  return isUnitQuaternion(result);
+};

--- a/client/src/utils/kawasaki.ts
+++ b/client/src/utils/kawasaki.ts
@@ -1,17 +1,21 @@
 import { CP, EdgeAssignment, Point } from "../types/cp";
-import { pointsEqual } from "./cp";
-import { Quaternion, isUnitQuaternion, multiplyQuaternions } from "./quaternions";
+import { getOtherVertex, isEndpoint, pointsEqual } from "./cp";
+import {
+  Quaternion,
+  isIdentityRotation,
+  multiplyQuaternions,
+} from "./quaternions";
 
 export const checkVertexFoldable = (vertex: Point, cp: CP): boolean => {
   // Find all edges connected to this vertex
-  const connectedEdges = cp.edges.filter(
-    (e) => pointsEqual(e.vertex1, vertex) || pointsEqual(e.vertex2, vertex)
-  );
+  const connectedEdges = cp.edges.filter((e) => isEndpoint(e, vertex));
 
   // If there are any border or cut edges connected, it's foldable (not constrained)
   if (
     connectedEdges.some(
-      (e) => e.assignment === EdgeAssignment.Border || e.assignment === EdgeAssignment.Cut
+      (e) =>
+        e.assignment === EdgeAssignment.Border ||
+        e.assignment === EdgeAssignment.Cut,
     )
   ) {
     return true;
@@ -23,7 +27,7 @@ export const checkVertexFoldable = (vertex: Point, cp: CP): boolean => {
     (e) =>
       e.assignment === EdgeAssignment.Mountain ||
       e.assignment === EdgeAssignment.Valley ||
-      e.assignment === EdgeAssignment.Flat
+      e.assignment === EdgeAssignment.Flat,
   );
 
   if (foldEdges.length === 0) return true;
@@ -31,7 +35,7 @@ export const checkVertexFoldable = (vertex: Point, cp: CP): boolean => {
   // Gather theta and rho
   const edgeData = foldEdges.map((e) => {
     // Determine the vector pointing AWAY from the vertex
-    const otherPoint = pointsEqual(e.vertex1, vertex) ? e.vertex2 : e.vertex1;
+    const otherPoint = getOtherVertex(e, vertex);
     const dx = otherPoint.x - vertex.x;
     const dy = otherPoint.y - vertex.y;
     const theta = Math.atan2(dy, dx);
@@ -58,5 +62,5 @@ export const checkVertexFoldable = (vertex: Point, cp: CP): boolean => {
     result = multiplyQuaternions(result, quaternions[i]);
   }
 
-  return isUnitQuaternion(result);
+  return isIdentityRotation(result);
 };

--- a/client/src/utils/quaternions.ts
+++ b/client/src/utils/quaternions.ts
@@ -1,6 +1,9 @@
 export type Quaternion = [number, number, number, number]; // [w, x, y, z]
 
-export const multiplyQuaternions = (q1: Quaternion, q2: Quaternion): Quaternion => {
+export const multiplyQuaternions = (
+  q1: Quaternion,
+  q2: Quaternion,
+): Quaternion => {
   const [w1, x1, y1, z1] = q1;
   const [w2, x2, y2, z2] = q2;
 
@@ -12,12 +15,17 @@ export const multiplyQuaternions = (q1: Quaternion, q2: Quaternion): Quaternion 
   ];
 };
 
-export const isUnitQuaternion = (q: Quaternion, tolerance: number = 1e-4): boolean => {
+export const isIdentityRotation = (
+  q: Quaternion,
+  tolerance: number = 1e-4,
+): boolean => {
   const [w, x, y, z] = q;
   // It is the identity rotation if w is close to 1 or -1, and x, y, z are close to 0.
   // We check if the real part magnitude is close to 1.
-  return Math.abs(Math.abs(w) - 1) < tolerance &&
-         Math.abs(x) < tolerance &&
-         Math.abs(y) < tolerance &&
-         Math.abs(z) < tolerance;
+  return (
+    Math.abs(Math.abs(w) - 1) < tolerance &&
+    Math.abs(x) < tolerance &&
+    Math.abs(y) < tolerance &&
+    Math.abs(z) < tolerance
+  );
 };

--- a/client/src/utils/quaternions.ts
+++ b/client/src/utils/quaternions.ts
@@ -1,0 +1,23 @@
+export type Quaternion = [number, number, number, number]; // [w, x, y, z]
+
+export const multiplyQuaternions = (q1: Quaternion, q2: Quaternion): Quaternion => {
+  const [w1, x1, y1, z1] = q1;
+  const [w2, x2, y2, z2] = q2;
+
+  return [
+    w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+    w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+    w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+    w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+  ];
+};
+
+export const isUnitQuaternion = (q: Quaternion, tolerance: number = 1e-4): boolean => {
+  const [w, x, y, z] = q;
+  // It is the identity rotation if w is close to 1 or -1, and x, y, z are close to 0.
+  // We check if the real part magnitude is close to 1.
+  return Math.abs(Math.abs(w) - 1) < tolerance &&
+         Math.abs(x) < tolerance &&
+         Math.abs(y) < tolerance &&
+         Math.abs(z) < tolerance;
+};

--- a/client/src/utils/xray.ts
+++ b/client/src/utils/xray.ts
@@ -227,12 +227,10 @@ const shouldFlip = (face: Face, edge: Edge) => {
   }
   return false; 
 };
-
 export const foldFaces = (faces: Face[], cp: CP): FoldedFace[] => {
   if (!faces || faces.length === 0) return [];
 
-  // Derive adjacency strictly from the faces themselves, rather than cp.edges.
-  // This allows it to handle the dynamically merged edges we created in findFaces.
+  // Derive adjacency strictly from the faces themselves
   const edgeFaces = new Map<string, { edge: Edge; faces: Face[] }>();
 
   faces.forEach((f: Face) =>
@@ -249,8 +247,13 @@ export const foldFaces = (faces: Face[], cp: CP): FoldedFace[] => {
   
   edgeFaces.forEach(({ edge, faces: fs }) => {
     if (fs.length === 2) {
-      faceAdj.get(fs[0])!.push({ face: fs[1], edge: edge });
-      faceAdj.get(fs[1])!.push({ face: fs[0], edge: edge });
+      // ADJACENCY CHECK: Only connect faces across Mountain or Valley folds.
+      // Border edges ('B') or internal cuts will effectively split the graph.
+      const assignment = (edge as any).assignment;
+      if (assignment === "M" || assignment === "V") {
+        faceAdj.get(fs[0])!.push({ face: fs[1], edge: edge });
+        faceAdj.get(fs[1])!.push({ face: fs[0], edge: edge });
+      }
     }
   });
 
@@ -265,17 +268,28 @@ export const foldFaces = (faces: Face[], cp: CP): FoldedFace[] => {
       dfsFaces(e.face, { ...e, face: face });
     });
   };
-  dfsFaces(faces[0]);
+
+  // SPANNING FOREST: Start a DFS for every unvisited face to handle 
+  // multiple disconnected components/sub-graphs.
+  faces.forEach((f: Face) => {
+    if (!facesVisited.has(f)) {
+      dfsFaces(f, null); 
+    }
+  });
 
   return faces.map((f: Face) => {
     let curFace = f;
     let points = f.border.map((p: Point) => [p.x, p.y, 0] as Point3D);
     let par;
+    
+    // This will naturally stop at the local root of whichever 
+    // disconnected component the curFace belongs to.
     while ((par = faceParent.get(curFace))) {
       const flip = shouldFlip(curFace, par.edge) ? -1 : 1;
       points = rotateFace(points, par.edge, flip);
       curFace = par.face;
     }
+    
     return { border: points, id: f.id };
   });
 };

--- a/client/src/utils/xray.ts
+++ b/client/src/utils/xray.ts
@@ -4,13 +4,12 @@ import { getOtherVertex, pointToKey, pointsEqual } from "./cp";
 
 const DISTORTION = 0.001; // how much to distort the face when folding
 
-
 const getSignedArea = (points: Point[]): number => {
   let area = 0;
   for (let i = 0; i < points.length; i++) {
     const p1 = points[i];
     const p2 = points[(i + 1) % points.length];
-    area += (p1.x * p2.y - p2.x * p1.y);
+    area += p1.x * p2.y - p2.x * p1.y;
   }
   return area / 2;
 };
@@ -24,15 +23,6 @@ const getEdgeAngle = (e: Edge, reference: Point): number => {
   return Math.atan2(other.y - reference.y, other.x - reference.x);
 };
 
-// const isFaceClockwise = (face: Point[]): boolean => {
-//   const sum = face
-//     .map((p1: Point, ind: number) => {
-//       const p2 = face[(ind + 1) % face.length];
-//       return p1.x * p2.y - p2.x * p1.y;
-//     })
-//     .reduce((acc: number, curr: number) => acc + curr);
-//   return sum < 0;
-// };
 const traceFace = (
   startVertex: Point,
   startEdge: Edge,
@@ -52,15 +42,20 @@ const traceFace = (
     usedEdges.add(getDirectedEdgeKey(currentVertex, nextVertex));
 
     const edgesAtVertex = edgeMap.get(pointToKey(nextVertex));
-    if (!edgesAtVertex) throw new Error("Graph disjointed: Vertex not found in edge map.");
+    if (!edgesAtVertex)
+      throw new Error("Graph disjointed: Vertex not found in edge map.");
 
-    const currentIndex = edgesAtVertex.findIndex((e) => e.id === currentEdge.id);
-    if (currentIndex === -1) throw new Error("Graph disjointed: Edge missing from vertex.");
+    const currentIndex = edgesAtVertex.findIndex(
+      (e) => e.id === currentEdge.id,
+    );
+    if (currentIndex === -1)
+      throw new Error("Graph disjointed: Edge missing from vertex.");
 
     // THE FIX: Use - 1 to make "Left Turns" (Counter-Clockwise traversal)
     // We add edgesAtVertex.length before modulo to handle negative numbers in JS
-    const nextIndex = (currentIndex - 1 + edgesAtVertex.length) % edgesAtVertex.length;
-    
+    const nextIndex =
+      (currentIndex - 1 + edgesAtVertex.length) % edgesAtVertex.length;
+
     currentEdge = edgesAtVertex[nextIndex];
     currentVertex = nextVertex;
   } while (!pointsEqual(currentVertex, startVertex));
@@ -71,23 +66,29 @@ const traceFace = (
 export const findFaces = (cp: CP): Face[] => {
   // 1. Filter out non-structural lines
   let activeEdges = cp.edges.filter(
-    (e: any) => e.assignment !== "A" && e.assignment !== "F"
+    (e: any) => e.assignment !== "A" && e.assignment !== "F",
   );
 
   // 2. Iteratively merge collinear edges (Robustly decoupled from cp.vertices)
   let changed = true;
   while (changed) {
     changed = false;
-    
+
     // Dynamically map vertices strictly from current activeEdges
     const vMap = new Map<string, Edge[]>();
     const vPoints = new Map<string, Point>();
-    
+
     activeEdges.forEach((e) => {
       const k1 = pointToKey(e.vertex1);
       const k2 = pointToKey(e.vertex2);
-      if (!vMap.has(k1)) { vMap.set(k1, []); vPoints.set(k1, e.vertex1); }
-      if (!vMap.has(k2)) { vMap.set(k2, []); vPoints.set(k2, e.vertex2); }
+      if (!vMap.has(k1)) {
+        vMap.set(k1, []);
+        vPoints.set(k1, e.vertex1);
+      }
+      if (!vMap.has(k2)) {
+        vMap.set(k2, []);
+        vPoints.set(k2, e.vertex2);
+      }
       vMap.get(k1)!.push(e);
       vMap.get(k2)!.push(e);
     });
@@ -100,13 +101,17 @@ export const findFaces = (cp: CP): Face[] => {
         const other2 = getOtherVertex(e2, v);
 
         // Check collinearity
-        const cross = (other1.x - v.x) * (other2.y - v.y) - (other1.y - v.y) * (other2.x - v.x);
-        const dot = (other1.x - v.x) * (other2.x - v.x) + (other1.y - v.y) * (other2.y - v.y);
+        const cross =
+          (other1.x - v.x) * (other2.y - v.y) -
+          (other1.y - v.y) * (other2.x - v.x);
+        const dot =
+          (other1.x - v.x) * (other2.x - v.x) +
+          (other1.y - v.y) * (other2.y - v.y);
 
         if (Math.abs(cross) < 1e-7 && dot < 0) {
-          const a1 = (e1 as any).assignment;
-          const a2 = (e2 as any).assignment;
-          
+          const a1 = e1.assignment;
+          const a2 = e2.assignment;
+
           if (a1 === a2 && e1.foldAngle === e2.foldAngle) {
             const newEdge: Edge = {
               ...e1,
@@ -114,8 +119,10 @@ export const findFaces = (cp: CP): Face[] => {
               vertex1: other1,
               vertex2: other2,
             };
-            
-            activeEdges = activeEdges.filter((e) => e.id !== e1.id && e.id !== e2.id);
+
+            activeEdges = activeEdges.filter(
+              (e) => e.id !== e1.id && e.id !== e2.id,
+            );
             activeEdges.push(newEdge);
             changed = true;
             break; // Restart loop with fresh activeEdges
@@ -133,10 +140,16 @@ export const findFaces = (cp: CP): Face[] => {
   activeEdges.forEach((edge) => {
     const k1 = pointToKey(edge.vertex1);
     const k2 = pointToKey(edge.vertex2);
-    
-    if (!edgeMap.has(k1)) { edgeMap.set(k1, []); pointMap.set(k1, edge.vertex1); }
-    if (!edgeMap.has(k2)) { edgeMap.set(k2, []); pointMap.set(k2, edge.vertex2); }
-    
+
+    if (!edgeMap.has(k1)) {
+      edgeMap.set(k1, []);
+      pointMap.set(k1, edge.vertex1);
+    }
+    if (!edgeMap.has(k2)) {
+      edgeMap.set(k2, []);
+      pointMap.set(k2, edge.vertex2);
+    }
+
     edgeMap.get(k1)!.push(edge);
     edgeMap.get(k2)!.push(edge);
   });
@@ -151,16 +164,16 @@ export const findFaces = (cp: CP): Face[] => {
   const usedDirectedEdges = new Set<string>();
 
   // TRAVERSAL: Find all minimal cycles (faces)
-  activeEdges.forEach(edge => {
-    [edge.vertex1, edge.vertex2].forEach(v => {
+  activeEdges.forEach((edge) => {
+    [edge.vertex1, edge.vertex2].forEach((v) => {
       const nextV = getOtherVertex(edge, v);
       const key = getDirectedEdgeKey(v, nextV);
-      
+
       if (usedDirectedEdges.has(key)) return;
 
       const currentFace = traceFace(v, edge, edgeMap, usedDirectedEdges);
-      
-      // Because we use `currentIndex - 1` (Left Turns), internal minimal 
+
+      // Because we use `currentIndex - 1` (Left Turns), internal minimal
       // faces will be CCW (Area > 0). The infinite face will trace CW (Area < 0).
       const area = getSignedArea(currentFace.border);
       if (area > 0) {
@@ -200,8 +213,14 @@ const rotateFace = (
     const dot = u[0] * pRel[0] + u[1] * pRel[1] + u[2] * pRel[2];
 
     const rotated = [
-      A.x + cosTheta * pRel[0] + sinTheta * cross[0] + (1 - cosTheta) * dot * u[0],
-      A.y + cosTheta * pRel[1] + sinTheta * cross[1] + (1 - cosTheta) * dot * u[1],
+      A.x +
+        cosTheta * pRel[0] +
+        sinTheta * cross[0] +
+        (1 - cosTheta) * dot * u[0],
+      A.y +
+        cosTheta * pRel[1] +
+        sinTheta * cross[1] +
+        (1 - cosTheta) * dot * u[1],
       cosTheta * pRel[2] + sinTheta * cross[2] + (1 - cosTheta) * dot * u[2],
     ];
 
@@ -221,11 +240,13 @@ const shouldFlip = (face: Face, edge: Edge) => {
     const p1 = face.border[i];
     const p2 = face.border[(i + 1) % n];
     // If we find the edge in standard sequence, no flip required
-    if (pointsEqual(p1, edge.vertex1) && pointsEqual(p2, edge.vertex2)) return false;
+    if (pointsEqual(p1, edge.vertex1) && pointsEqual(p2, edge.vertex2))
+      return false;
     // If we find the edge in reverse sequence, flip is required
-    if (pointsEqual(p1, edge.vertex2) && pointsEqual(p2, edge.vertex1)) return true;
+    if (pointsEqual(p1, edge.vertex2) && pointsEqual(p2, edge.vertex1))
+      return true;
   }
-  return false; 
+  return false;
 };
 export const foldFaces = (faces: Face[], cp: CP): FoldedFace[] => {
   if (!faces || faces.length === 0) return [];
@@ -244,12 +265,12 @@ export const foldFaces = (faces: Face[], cp: CP): FoldedFace[] => {
 
   const faceAdj = new Map<Face, FaceEdge[]>();
   faces.forEach((f: Face) => faceAdj.set(f, []));
-  
+
   edgeFaces.forEach(({ edge, faces: fs }) => {
     if (fs.length === 2) {
       // ADJACENCY CHECK: Only connect faces across Mountain or Valley folds.
       // Border edges ('B') or internal cuts will effectively split the graph.
-      const assignment = (edge as any).assignment;
+      const assignment = edge.assignment;
       if (assignment === "M" || assignment === "V") {
         faceAdj.get(fs[0])!.push({ face: fs[1], edge: edge });
         faceAdj.get(fs[1])!.push({ face: fs[0], edge: edge });
@@ -259,7 +280,7 @@ export const foldFaces = (faces: Face[], cp: CP): FoldedFace[] => {
 
   const faceParent = new Map<Face, FaceEdge | null>();
   const facesVisited = new Set<Face>();
-  
+
   const dfsFaces = (face: Face, from: FaceEdge | null = null) => {
     faceParent.set(face, from);
     facesVisited.add(face);
@@ -269,11 +290,11 @@ export const foldFaces = (faces: Face[], cp: CP): FoldedFace[] => {
     });
   };
 
-  // SPANNING FOREST: Start a DFS for every unvisited face to handle 
+  // SPANNING FOREST: Start a DFS for every unvisited face to handle
   // multiple disconnected components/sub-graphs.
   faces.forEach((f: Face) => {
     if (!facesVisited.has(f)) {
-      dfsFaces(f, null); 
+      dfsFaces(f, null);
     }
   });
 
@@ -281,15 +302,15 @@ export const foldFaces = (faces: Face[], cp: CP): FoldedFace[] => {
     let curFace = f;
     let points = f.border.map((p: Point) => [p.x, p.y, 0] as Point3D);
     let par;
-    
-    // This will naturally stop at the local root of whichever 
+
+    // This will naturally stop at the local root of whichever
     // disconnected component the curFace belongs to.
     while ((par = faceParent.get(curFace))) {
       const flip = shouldFlip(curFace, par.edge) ? -1 : 1;
       points = rotateFace(points, par.edge, flip);
       curFace = par.face;
     }
-    
+
     return { border: points, id: f.id };
   });
 };

--- a/client/src/utils/xray.ts
+++ b/client/src/utils/xray.ts
@@ -4,6 +4,17 @@ import { getOtherVertex, pointToKey, pointsEqual } from "./cp";
 
 const DISTORTION = 0.001; // how much to distort the face when folding
 
+
+const getSignedArea = (points: Point[]): number => {
+  let area = 0;
+  for (let i = 0; i < points.length; i++) {
+    const p1 = points[i];
+    const p2 = points[(i + 1) % points.length];
+    area += (p1.x * p2.y - p2.x * p1.y);
+  }
+  return area / 2;
+};
+
 const getDirectedEdgeKey = (v1: Point, v2: Point) => {
   return `Edge${pointToKey(v1)}-${pointToKey(v2)}`;
 };
@@ -13,16 +24,15 @@ const getEdgeAngle = (e: Edge, reference: Point): number => {
   return Math.atan2(other.y - reference.y, other.x - reference.x);
 };
 
-const isFaceClockwise = (face: Point[]): boolean => {
-  const sum = face
-    .map((p1: Point, ind: number) => {
-      const p2 = face[(ind + 1) % face.length];
-      return p1.x * p2.y - p2.x * p1.y;
-    })
-    .reduce((acc: number, curr: number) => acc + curr);
-  return sum < 0;
-};
-
+// const isFaceClockwise = (face: Point[]): boolean => {
+//   const sum = face
+//     .map((p1: Point, ind: number) => {
+//       const p2 = face[(ind + 1) % face.length];
+//       return p1.x * p2.y - p2.x * p1.y;
+//     })
+//     .reduce((acc: number, curr: number) => acc + curr);
+//   return sum < 0;
+// };
 const traceFace = (
   startVertex: Point,
   startEdge: Edge,
@@ -35,22 +45,22 @@ const traceFace = (
   let currentEdge = startEdge;
 
   do {
-    // Get next vertex
     const nextVertex = getOtherVertex(currentEdge, currentVertex);
     face.push(nextVertex);
     edges.push(currentEdge);
 
-    // Mark edge as used
     usedEdges.add(getDirectedEdgeKey(currentVertex, nextVertex));
 
-    // Find next edge (next counter-clockwise edge)
-    const edgesAtVertex = edgeMap.get(pointToKey(nextVertex))!;
-    const currentIndex = edgesAtVertex.findIndex(
-      (e) => e.id === currentEdge.id,
-    );
+    const edgesAtVertex = edgeMap.get(pointToKey(nextVertex));
+    if (!edgesAtVertex) throw new Error("Graph disjointed: Vertex not found in edge map.");
 
-    // Get the next edge in counter-clockwise order
-    const nextIndex = (currentIndex + 1) % edgesAtVertex.length;
+    const currentIndex = edgesAtVertex.findIndex((e) => e.id === currentEdge.id);
+    if (currentIndex === -1) throw new Error("Graph disjointed: Edge missing from vertex.");
+
+    // THE FIX: Use - 1 to make "Left Turns" (Counter-Clockwise traversal)
+    // We add edgesAtVertex.length before modulo to handle negative numbers in JS
+    const nextIndex = (currentIndex - 1 + edgesAtVertex.length) % edgesAtVertex.length;
+    
     currentEdge = edgesAtVertex[nextIndex];
     currentVertex = nextVertex;
   } while (!pointsEqual(currentVertex, startVertex));
@@ -59,60 +69,108 @@ const traceFace = (
 };
 
 export const findFaces = (cp: CP): Face[] => {
-  // 1. Build adjacency structure
+  // 1. Filter out non-structural lines
+  let activeEdges = cp.edges.filter(
+    (e: any) => e.assignment !== "A" && e.assignment !== "F"
+  );
+
+  // 2. Iteratively merge collinear edges (Robustly decoupled from cp.vertices)
+  let changed = true;
+  while (changed) {
+    changed = false;
+    
+    // Dynamically map vertices strictly from current activeEdges
+    const vMap = new Map<string, Edge[]>();
+    const vPoints = new Map<string, Point>();
+    
+    activeEdges.forEach((e) => {
+      const k1 = pointToKey(e.vertex1);
+      const k2 = pointToKey(e.vertex2);
+      if (!vMap.has(k1)) { vMap.set(k1, []); vPoints.set(k1, e.vertex1); }
+      if (!vMap.has(k2)) { vMap.set(k2, []); vPoints.set(k2, e.vertex2); }
+      vMap.get(k1)!.push(e);
+      vMap.get(k2)!.push(e);
+    });
+
+    for (const [vKey, edges] of vMap.entries()) {
+      if (edges.length === 2) {
+        const [e1, e2] = edges;
+        const v = vPoints.get(vKey)!;
+        const other1 = getOtherVertex(e1, v);
+        const other2 = getOtherVertex(e2, v);
+
+        // Check collinearity
+        const cross = (other1.x - v.x) * (other2.y - v.y) - (other1.y - v.y) * (other2.x - v.x);
+        const dot = (other1.x - v.x) * (other2.x - v.x) + (other1.y - v.y) * (other2.y - v.y);
+
+        if (Math.abs(cross) < 1e-7 && dot < 0) {
+          const a1 = (e1 as any).assignment;
+          const a2 = (e2 as any).assignment;
+          
+          if (a1 === a2 && e1.foldAngle === e2.foldAngle) {
+            const newEdge: Edge = {
+              ...e1,
+              id: crypto.randomUUID(),
+              vertex1: other1,
+              vertex2: other2,
+            };
+            
+            activeEdges = activeEdges.filter((e) => e.id !== e1.id && e.id !== e2.id);
+            activeEdges.push(newEdge);
+            changed = true;
+            break; // Restart loop with fresh activeEdges
+          }
+        }
+      }
+    }
+  }
+
+  // --- BUILD FINAL ADJACENCY ---
   const edgeMap = new Map<string, Edge[]>();
   const pointMap = new Map<string, Point>();
 
-  cp.vertices.forEach((v) => {
-    const key = pointToKey(v);
-    edgeMap.set(key, []);
-    pointMap.set(key, v);
+  // Again, build pointMap strictly from activeEdges to prevent ghost vertices
+  activeEdges.forEach((edge) => {
+    const k1 = pointToKey(edge.vertex1);
+    const k2 = pointToKey(edge.vertex2);
+    
+    if (!edgeMap.has(k1)) { edgeMap.set(k1, []); pointMap.set(k1, edge.vertex1); }
+    if (!edgeMap.has(k2)) { edgeMap.set(k2, []); pointMap.set(k2, edge.vertex2); }
+    
+    edgeMap.get(k1)!.push(edge);
+    edgeMap.get(k2)!.push(edge);
   });
 
-  cp.edges.forEach((edge) => {
-    const key1 = pointToKey(edge.vertex1);
-    const key2 = pointToKey(edge.vertex2);
-    edgeMap.get(key1)!.push(edge);
-    edgeMap.get(key2)!.push(edge);
-  });
-
-  // 2. Sort edges around each vertex by angle
+  // Sort edges around each vertex by angle
   edgeMap.forEach((edges, vertexKey) => {
-    const vertex = pointMap.get(vertexKey);
-    if (!vertex) {
-      throw `Vertex ${vertexKey} not found in pointMap!`;
-    }
-    edges.sort((a, b) => {
-      const angleA = getEdgeAngle(a, vertex);
-      const angleB = getEdgeAngle(b, vertex);
-      return angleA - angleB;
-    });
+    const v = pointMap.get(vertexKey)!;
+    edges.sort((a, b) => getEdgeAngle(a, v) - getEdgeAngle(b, v));
   });
 
-  // 3. Traverse to find faces
   const faces: Face[] = [];
-  const usedEdges = new Set<string>();
+  const usedDirectedEdges = new Set<string>();
 
-  cp.edges.forEach((edge) => {
-    // Try both directions
-    [edge.vertex1, edge.vertex2].forEach((startVertex) => {
-      const edgeKey = getDirectedEdgeKey(
-        startVertex,
-        getOtherVertex(edge, startVertex),
-      );
+  // TRAVERSAL: Find all minimal cycles (faces)
+  activeEdges.forEach(edge => {
+    [edge.vertex1, edge.vertex2].forEach(v => {
+      const nextV = getOtherVertex(edge, v);
+      const key = getDirectedEdgeKey(v, nextV);
+      
+      if (usedDirectedEdges.has(key)) return;
 
-      if (usedEdges.has(edgeKey)) return;
-
-      const face = traceFace(startVertex, edge, edgeMap, usedEdges);
-      if (face.border.length >= 3 && isFaceClockwise(face.border)) {
-        faces.push(face);
+      const currentFace = traceFace(v, edge, edgeMap, usedDirectedEdges);
+      
+      // Because we use `currentIndex - 1` (Left Turns), internal minimal 
+      // faces will be CCW (Area > 0). The infinite face will trace CW (Area < 0).
+      const area = getSignedArea(currentFace.border);
+      if (area > 0) {
+        faces.push(currentFace);
       }
     });
   });
 
   return faces;
 };
-
 const rotateFace = (
   face: Point3D[],
   edge: Edge,
@@ -121,7 +179,6 @@ const rotateFace = (
   const { vertex1: A, vertex2: B } = edge;
 
   const axis = [B.x - A.x, B.y - A.y, 0];
-
   const axisLength = Math.hypot(axis[0], axis[1], axis[2]);
   if (axisLength === 0) throw new Error("Edge points must be different.");
 
@@ -142,16 +199,9 @@ const rotateFace = (
 
     const dot = u[0] * pRel[0] + u[1] * pRel[1] + u[2] * pRel[2];
 
-    // Rodrigues' rotation formula
     const rotated = [
-      A.x +
-        cosTheta * pRel[0] +
-        sinTheta * cross[0] +
-        (1 - cosTheta) * dot * u[0],
-      A.y +
-        cosTheta * pRel[1] +
-        sinTheta * cross[1] +
-        (1 - cosTheta) * dot * u[1],
+      A.x + cosTheta * pRel[0] + sinTheta * cross[0] + (1 - cosTheta) * dot * u[0],
+      A.y + cosTheta * pRel[1] + sinTheta * cross[1] + (1 - cosTheta) * dot * u[1],
       cosTheta * pRel[2] + sinTheta * cross[2] + (1 - cosTheta) * dot * u[2],
     ];
 
@@ -164,28 +214,40 @@ interface FaceEdge {
   edge: Edge;
 }
 
+// Updated to robustly handle duplicate border vertices and merged edges
 const shouldFlip = (face: Face, edge: Edge) => {
-  const v1Ind = face.border.findIndex((p: Point) =>
-    pointsEqual(p, edge.vertex1),
-  );
-  const v2Ind = face.border.findIndex((p: Point) =>
-    pointsEqual(p, edge.vertex2),
-  );
-  return (v2Ind - v1Ind + face.border.length) % face.border.length !== 1;
+  const n = face.border.length;
+  for (let i = 0; i < n; i++) {
+    const p1 = face.border[i];
+    const p2 = face.border[(i + 1) % n];
+    // If we find the edge in standard sequence, no flip required
+    if (pointsEqual(p1, edge.vertex1) && pointsEqual(p2, edge.vertex2)) return false;
+    // If we find the edge in reverse sequence, flip is required
+    if (pointsEqual(p1, edge.vertex2) && pointsEqual(p2, edge.vertex1)) return true;
+  }
+  return false; 
 };
 
 export const foldFaces = (faces: Face[], cp: CP): FoldedFace[] => {
-  // Calculate spanning tree
-  const edgeFaces = new Map<Edge, Face[]>();
+  if (!faces || faces.length === 0) return [];
 
-  cp.edges.forEach((e: Edge) => edgeFaces.set(e, []));
+  // Derive adjacency strictly from the faces themselves, rather than cp.edges.
+  // This allows it to handle the dynamically merged edges we created in findFaces.
+  const edgeFaces = new Map<string, { edge: Edge; faces: Face[] }>();
+
   faces.forEach((f: Face) =>
-    f.edges.forEach((e: Edge) => edgeFaces.get(e)!.push(f)),
+    f.edges.forEach((e: Edge) => {
+      if (!edgeFaces.has(e.id)) {
+        edgeFaces.set(e.id, { edge: e, faces: [] });
+      }
+      edgeFaces.get(e.id)!.faces.push(f);
+    }),
   );
 
   const faceAdj = new Map<Face, FaceEdge[]>();
   faces.forEach((f: Face) => faceAdj.set(f, []));
-  edgeFaces.forEach((fs: Face[], edge: Edge) => {
+  
+  edgeFaces.forEach(({ edge, faces: fs }) => {
     if (fs.length === 2) {
       faceAdj.get(fs[0])!.push({ face: fs[1], edge: edge });
       faceAdj.get(fs[1])!.push({ face: fs[0], edge: edge });
@@ -194,6 +256,7 @@ export const foldFaces = (faces: Face[], cp: CP): FoldedFace[] => {
 
   const faceParent = new Map<Face, FaceEdge | null>();
   const facesVisited = new Set<Face>();
+  
   const dfsFaces = (face: Face, from: FaceEdge | null = null) => {
     faceParent.set(face, from);
     facesVisited.add(face);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,7 +28,7 @@ export default [
   {
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-unused-vars": "warn", // Change to error once project is stable
+      "@typescript-eslint/no-unused-vars": "error",
       "@typescript-eslint/no-empty-object-type": "warn",
       "react/no-unescaped-entities": "warn",
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1145,20 +1145,22 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1191,19 +1193,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -1214,10 +1217,11 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1236,10 +1240,11 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2112,10 +2117,11 @@
       }
     },
     "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2124,228 +2130,325 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.35.0.tgz",
-      "integrity": "sha512-uYQ2WfPaqz5QtVgMxfN6NpLD+no0MYHDBywl7itPYd3K5TjjSghNKmX8ic9S8NU8w81NVhJv/XojcHptRly7qQ==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.35.0.tgz",
-      "integrity": "sha512-FtKddj9XZudurLhdJnBl9fl6BwCJ3ky8riCXjEw3/UIbjmIY58ppWwPEvU3fNu+W7FUsAsB1CdH+7EQE6CXAPA==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.35.0.tgz",
-      "integrity": "sha512-Uk+GjOJR6CY844/q6r5DR/6lkPFOw0hjfOIzVx22THJXMxktXG6CbejseJFznU8vHcEBLpiXKY3/6xc+cBm65Q==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.35.0.tgz",
-      "integrity": "sha512-3IrHjfAS6Vkp+5bISNQnPogRAW5GAV1n+bNCrDwXmfMHbPl5EhTmWtfmwlJxFRUCBZ+tZ/OxDyU08aF6NI/N5Q==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.35.0.tgz",
-      "integrity": "sha512-sxjoD/6F9cDLSELuLNnY0fOrM9WA0KrM0vWm57XhrIMf5FGiN8D0l7fn+bpUeBSU7dCgPV2oX4zHAsAXyHFGcQ==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.35.0.tgz",
-      "integrity": "sha512-2mpHCeRuD1u/2kruUiHSsnjWtHjqVbzhBkNVQ1aVD63CcexKVcQGwJ2g5VphOd84GvxfSvnnlEyBtQCE5hxVVw==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.35.0.tgz",
-      "integrity": "sha512-mrA0v3QMy6ZSvEuLs0dMxcO2LnaCONs1Z73GUDBHWbY8tFFocM6yl7YyMu7rz4zS81NDSqhrUuolyZXGi8TEqg==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.35.0.tgz",
-      "integrity": "sha512-DnYhhzcvTAKNexIql8pFajr0PiDGrIsBYPRvCKlA5ixSS3uwo/CWNZxB09jhIapEIg945KOzcYEAGGSmTSpk7A==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.35.0.tgz",
-      "integrity": "sha512-uagpnH2M2g2b5iLsCTZ35CL1FgyuzzJQ8L9VtlJ+FckBXroTwNOaD0z0/UF+k5K3aNQjbm8LIVpxykUOQt1m/A==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.35.0.tgz",
-      "integrity": "sha512-XQxVOCd6VJeHQA/7YcqyV0/88N6ysSVzRjJ9I9UA/xXpEsjvAgDTgH3wQYz5bmr7SPtVK2TsP2fQ2N9L4ukoUg==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.35.0.tgz",
-      "integrity": "sha512-5pMT5PzfgwcXEwOaSrqVsz/LvjDZt+vQ8RT/70yhPU06PTuq8WaHhfT1LW+cdD7mW6i/J5/XIkX/1tCAkh1W6g==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
       "cpu": [
         "loong64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.35.0.tgz",
-      "integrity": "sha512-c+zkcvbhbXF98f4CtEIP1EBA/lCic5xB0lToneZYvMeKu5Kamq3O8gqrxiYYLzlZH6E3Aq+TSW86E4ay8iD8EA==",
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
       "cpu": [
         "ppc64"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.35.0.tgz",
-      "integrity": "sha512-s91fuAHdOwH/Tad2tzTtPX7UZyytHIRR6V4+2IGlV0Cej5rkG0R61SX4l4y9sh0JBibMiploZx3oHKPnQBKe4g==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
       "cpu": [
         "riscv64"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.35.0.tgz",
-      "integrity": "sha512-hQRkPQPLYJZYGP+Hj4fR9dDBMIM7zrzJDWFEMPdTnTy95Ljnv0/4w/ixFw3pTBMEuuEuoqtBINYND4M7ujcuQw==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
       "cpu": [
         "s390x"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.35.0.tgz",
-      "integrity": "sha512-Pim1T8rXOri+0HmV4CdKSGrqcBWX0d1HoPnQ0uw0bdp1aP5SdQVNBy8LjYncvnLgu3fnnCt17xjWGd4cqh8/hA==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.35.0.tgz",
-      "integrity": "sha512-QysqXzYiDvQWfUiTm8XmJNO2zm9yC9P/2Gkrwg2dH9cxotQzunBHYr6jk4SujCTqnfGxduOmQcI7c2ryuW8XVg==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.35.0.tgz",
-      "integrity": "sha512-OUOlGqPkVJCdJETKOCEf1mw848ZyJ5w50/rZ/3IBQVdLfR5jk/6Sr5m3iO2tdPgwo0x7VcncYuOvMhBWZq8ayg==",
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.35.0.tgz",
-      "integrity": "sha512-2/lsgejMrtwQe44glq7AFFHLfJBPafpsTa6JvP2NGef/ifOa4KBoglVf7AKN7EV9o32evBPRqfg96fEHzWo5kw==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.35.0.tgz",
-      "integrity": "sha512-PIQeY5XDkrOysbQblSW7v3l1MDZzkTEzAfTPkj5VAu3FW8fS4ynyLg2sINp0fp3SjZ8xkRYpLqoKcYqAkhU1dw==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -3192,9 +3295,10 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "5.0.0",
@@ -3837,14 +3941,28 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -3880,9 +3998,10 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3898,6 +4017,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
@@ -3912,9 +4032,10 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3931,6 +4052,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/ajv-keywords": {
@@ -4411,6 +4533,18 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.11",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.11.tgz",
+      "integrity": "sha512-DAKrHphkJyiGuau/cFieRYhcTFeK/lBuD++C7cZ6KZHbMhBrisoi+EvhQ5RZrIfV5qwsW8kgQ07JIC+MDJRAhg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -4510,10 +4644,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4530,9 +4665,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4547,11 +4682,13 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001688",
-        "electron-to-chromium": "^1.5.73",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.1"
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4706,9 +4843,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001704",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001704.tgz",
-      "integrity": "sha512-+L2IgBbV6gXB4ETf0keSvLr7JUrRVbIaB/lrQ1+z8mRcQiisG5k+lG6O4n6Y5q6f5EuNfaYXKgymucphlEXQew==",
+      "version": "1.0.30001781",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
+      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4722,7 +4859,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -5103,9 +5241,10 @@
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -5322,9 +5461,10 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.116",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.116.tgz",
-      "integrity": "sha512-mufxTCJzLBQVvSdZzX1s5YAuXsN1M4tTyYxOOL1TcSKtIzQ9rjIrm7yFK80rN5dwGTePgdoABDSHpuVtRQh0Zw=="
+      "version": "1.5.328",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
+      "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
+      "license": "ISC"
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -5480,12 +5620,13 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.0"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -5621,9 +5762,10 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
-      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/es-object-atoms": {
@@ -5884,10 +6026,11 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5903,10 +6046,11 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5956,20 +6100,22 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6032,10 +6178,11 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6054,10 +6201,11 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6383,9 +6531,9 @@
       "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w=="
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "funding": [
         {
           "type": "github",
@@ -6396,6 +6544,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "license": "BSD-3-Clause",
       "peer": true
     },
     "node_modules/fastq": {
@@ -6444,10 +6593,11 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -6526,10 +6676,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -6761,23 +6912,26 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause",
       "peer": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7745,20 +7899,22 @@
       }
     },
     "node_modules/jake/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/jake/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -8737,12 +8893,17 @@
       "dev": true
     },
     "node_modules/loader-runner": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/loader-utils": {
@@ -8774,9 +8935,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -8965,12 +9126,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -9262,9 +9424,10 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -9276,9 +9439,10 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "license": "MIT"
     },
     "node_modules/nodemon": {
       "version": "3.1.9",
@@ -9308,9 +9472,10 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -9325,9 +9490,10 @@
       }
     },
     "node_modules/nodemon/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -9665,9 +9831,10 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -9684,9 +9851,10 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -9937,9 +10105,10 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -9976,15 +10145,6 @@
       "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/range-parser": {
@@ -10870,11 +11030,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.35.0.tgz",
-      "integrity": "sha512-kg6oI4g+vc41vePJyO6dHt/yl0Rz3Thv0kJeVQ3D1kS3E5XSuKbPc29G4IpT/Kv1KQwgHVcN+HtyS+HYLNSvQg==",
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.6"
+        "@types/estree": "1.0.8"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -10884,25 +11045,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.35.0",
-        "@rollup/rollup-android-arm64": "4.35.0",
-        "@rollup/rollup-darwin-arm64": "4.35.0",
-        "@rollup/rollup-darwin-x64": "4.35.0",
-        "@rollup/rollup-freebsd-arm64": "4.35.0",
-        "@rollup/rollup-freebsd-x64": "4.35.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.35.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.35.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.35.0",
-        "@rollup/rollup-linux-arm64-musl": "4.35.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.35.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.35.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.35.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.35.0",
-        "@rollup/rollup-linux-x64-gnu": "4.35.0",
-        "@rollup/rollup-linux-x64-musl": "4.35.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.35.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.35.0",
-        "@rollup/rollup-win32-x64-msvc": "4.35.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.0",
+        "@rollup/rollup-android-arm64": "4.60.0",
+        "@rollup/rollup-darwin-arm64": "4.60.0",
+        "@rollup/rollup-darwin-x64": "4.60.0",
+        "@rollup/rollup-freebsd-arm64": "4.60.0",
+        "@rollup/rollup-freebsd-x64": "4.60.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
+        "@rollup/rollup-linux-arm64-musl": "4.60.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
+        "@rollup/rollup-linux-loong64-musl": "4.60.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-musl": "4.60.0",
+        "@rollup/rollup-openbsd-x64": "4.60.0",
+        "@rollup/rollup-openharmony-arm64": "4.60.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
+        "@rollup/rollup-win32-x64-gnu": "4.60.0",
+        "@rollup/rollup-win32-x64-msvc": "4.60.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -11088,15 +11255,6 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "peer": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/serve-static": {
@@ -11400,31 +11558,16 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1"
+        "debug": "~4.4.1"
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/socket.io-parser/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/socket.io/node_modules/debug": {
@@ -11764,11 +11907,16 @@
       "integrity": "sha512-92YT2dpt671tFiHH/e1ok9D987N9fHD5VWoly1CdPD/Cd1HMglvZwP3nx2yTj2lbXDAHt8QssZkxTLCCTNL+xw=="
     },
     "node_modules/tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/terser": {
@@ -11790,15 +11938,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-      "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {
@@ -11824,9 +11972,10 @@
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -11843,6 +11992,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
@@ -11855,6 +12005,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/node": "*",
@@ -11869,12 +12020,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
-      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
@@ -11894,6 +12047,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -11930,20 +12084,22 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -12032,9 +12188,10 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -12497,9 +12654,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "funding": [
         {
           "type": "opencollective",
@@ -12514,6 +12671,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -12717,9 +12875,10 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -12737,9 +12896,10 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
-      "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
@@ -12768,34 +12928,37 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.98.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
-      "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
+      "version": "5.105.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
+      "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
-        "@types/estree": "^1.0.6",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.14.0",
-        "browserslist": "^4.24.0",
+        "acorn": "^8.16.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.1",
-        "es-module-lexer": "^1.2.1",
+        "enhanced-resolve": "^5.20.0",
+        "es-module-lexer": "^2.0.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
         "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
+        "loader-runner": "^4.3.1",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.11",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.2.3"
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.17",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.4"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -12814,18 +12977,20 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
     },
     "node_modules/webpack/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -12842,6 +13007,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
@@ -12876,12 +13042,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/webpack/node_modules/schema-utils": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
-      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",


### PR DESCRIPTION
- **Made 3d viewing easier** Orbit controls fix the z axis to be vertical, which is annoying if the model is rendered sideways or upside down and can't be reoriented. Added sliders for yaw and roll so the user can manually reorient the model rightside up, then use orbit controls to view from different angles as before. The sliders currently do not adjust for dark mode.

- **Enabled the folding of multiple cps at once.** Previously the render would pick one root face and generate one spanning tree of the face adjacency graph. Now, it will look for disjoint components and create a separate spanning tree for each. The user currently cannot move the renders relative to each other.

- **Bug fixes for face finding** Fixed some bugs for face finding so now it always works for convex faces. There are still some remaining bugs for concave faces or faces with internal cuts, though.

- **Check Kawasaki foldability** Adds a checkbox to highlight non-foldable vertices on both the crease pattern and their resulting vertices on the 3d folded form. Kawasaki foldability is computed using quaternions instead of rotation matrices from before. This checkbox is currently placed in the "grid controls" box since it's also a display setting